### PR TITLE
Phase 6C: Server-side logging migration & documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,9 @@ logger.warn('Warning message');
 logger.error('Error occurred', error);
 ```
 
-The logger outputs structured JSON for Cloudflare Workers Logs, enabling filtering and analysis in the dashboard. Log level is controlled by the `LOG_LEVEL` feature flag.
+The logger outputs structured JSON for Cloudflare Workers Logs, enabling filtering and analysis in the dashboard. Log level is controlled by the `LOG_LEVEL` feature flag (changes propagate within 60 seconds due to config caching).
+
+**Log level propagation:** The logger is a singleton shared across the worker and Durable Objects. When `LOG_LEVEL` changes in GrowthBook, the new value propagates to KV instantly via webhook, then to running code within 60 seconds as config caches expire. During this window, some requests may briefly log at the old level. This is accepted eventual-consistency behavior.
 
 **Client-side logging** uses standard `console.*` methods:
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,7 @@ logger.error('Error occurred', error);
 
 The logger outputs structured JSON for Cloudflare Workers Logs, enabling filtering and analysis in the dashboard. Log level is controlled by the `LOG_LEVEL` feature flag (changes propagate within 60 seconds due to config caching).
 
-**Log level propagation:** The logger is a singleton shared across the worker and Durable Objects. When `LOG_LEVEL` changes in GrowthBook, the new value propagates to KV instantly via webhook, then to running code within 60 seconds as config caches expire. During this window, some requests may briefly log at the old level. This is accepted eventual-consistency behavior.
+**Log level propagation:** The logger is a module-level singleton. In Cloudflare Workers, the main worker and Durable Objects may run in separate isolates, each with their own logger instance. Both `worker.ts` and `server/poker-room.ts` call `logger.setLevel()` after loading config to ensure their respective logger instances are configured. When `LOG_LEVEL` changes in GrowthBook, the new value propagates to KV instantly via webhook, then to running code within 60 seconds as config caches expire. This is accepted eventual-consistency behavior.
 
 **Client-side logging** uses standard `console.*` methods:
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,7 @@ Client logs appear in the browser DevTools console. Use a `[ComponentName]` pref
 
 **Guidelines:**
 - Never import server logger utilities in client code (Vue components, composables)
+- Durable Objects should import and use the shared logger from `server/utils/logger.ts`
 - Use `logger.error()` for caught exceptions on the server
 - Avoid logging sensitive data (user IDs, session tokens, votes before reveal)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,34 @@ All user inputs (names, votes) are validated server-side:
 - Messages: Max 10KB size
 - Rate limiting: Max 10 messages/second
 
+### Logging Conventions
+
+**Server-side logging** uses the structured logger at `server/utils/logger.ts`:
+```typescript
+import { logger } from './logger';
+
+logger.debug('Detailed debugging info', { context: 'optional' });
+logger.info('General information');
+logger.warn('Warning message');
+logger.error('Error occurred', error);
+```
+
+The logger outputs structured JSON for Cloudflare Workers Logs, enabling filtering and analysis in the dashboard. Log level is controlled by the `LOG_LEVEL` feature flag.
+
+**Client-side logging** uses standard `console.*` methods:
+```typescript
+console.log('[ComponentName] Message');
+console.warn('[ComponentName] Warning');
+console.error('[ComponentName] Error:', error);
+```
+
+Client logs appear in the browser DevTools console. Use a `[ComponentName]` prefix for easier filtering.
+
+**Guidelines:**
+- Never import server logger utilities in client code (Vue components, composables)
+- Use `logger.error()` for caught exceptions on the server
+- Avoid logging sensitive data (user IDs, session tokens, votes before reveal)
+
 ## Testing Strategy
 
 ### Unit Tests

--- a/components/VotingArea.vue
+++ b/components/VotingArea.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// Bug fix: Removed server logger import (server code should not be imported in client components)
 import { PokerRoomKey } from '~/composables/usePokerRoom';
 import { useVotingScale } from '~/composables/useVotingScale';
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-// Bug fix: Use console.error directly instead of server logger import
-// (server code should not be imported in client components)
-
 const isCreating = ref(false);
 const error = ref('');
 

--- a/server/api/flags.get.ts
+++ b/server/api/flags.get.ts
@@ -1,4 +1,5 @@
 import { createConfig } from '../utils/config';
+import { logger } from '../utils/logger';
 
 /**
  * Flags API endpoint
@@ -22,7 +23,7 @@ export default defineEventHandler(async (event) => {
       timestamp: Date.now(),
     };
   } catch (error) {
-    console.error('Error fetching flags:', error);
+    logger.error('Error fetching flags', error);
 
     // Return error but don't fail - client should use cached values
     return {

--- a/server/utils/config.ts
+++ b/server/utils/config.ts
@@ -1,3 +1,5 @@
+import { logger } from './logger';
+
 // Flag value types
 export interface FlagDefaults {
   APP_ENABLED: boolean
@@ -50,14 +52,14 @@ export class Config {
       const payloadJson = await this.env.FLAGS_CACHE.get(PAYLOAD_KEY, 'text');
 
       if (!payloadJson) {
-        console.warn('No payload found in KV, using defaults');
+        logger.warn('No payload found in KV, using defaults');
         return {};
       }
 
       const payload = JSON.parse(payloadJson) as { features: Record<string, any> };
 
       if (!payload?.features) {
-        console.warn('Invalid payload structure in KV, using defaults');
+        logger.warn('Invalid payload structure in KV, using defaults');
         return {};
       }
 
@@ -76,7 +78,7 @@ export class Config {
 
       return flags;
     } catch (error) {
-      console.error('Failed to read flags from KV:', error);
+      logger.error('Failed to read flags from KV', error);
       return {};
     }
   }

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -16,15 +16,21 @@ class Logger {
   private level: LogLevel;
 
   constructor() {
-    // Default: WARN in production, DEBUG in development
+    // Default: INFO (balanced default if feature flag unavailable)
     // Can be overridden via setLevel() after config is loaded
-    this.level = process.env.NODE_ENV === 'production' ? LogLevel.WARN : LogLevel.DEBUG;
+    this.level = LogLevel.INFO;
   }
 
   /**
    * Set log level dynamically (called after config loads LOG_LEVEL flag)
+   * Defaults to INFO if an invalid level name is provided
    */
   setLevel(levelName: LogLevelName): void {
+    if (!(levelName in LogLevel)) {
+      console.error(`Invalid log level: ${levelName}, defaulting to INFO`);
+      this.level = LogLevel.INFO;
+      return;
+    }
     this.level = LogLevel[levelName];
   }
 

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -10,13 +10,22 @@ export enum LogLevel {
   ERROR = 3,
 }
 
+export type LogLevelName = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
 class Logger {
   private level: LogLevel;
 
   constructor() {
-    // In production, only log warnings and errors
-    // In development, log everything
+    // Default: WARN in production, DEBUG in development
+    // Can be overridden via setLevel() after config is loaded
     this.level = process.env.NODE_ENV === 'production' ? LogLevel.WARN : LogLevel.DEBUG;
+  }
+
+  /**
+   * Set log level dynamically (called after config loads LOG_LEVEL flag)
+   */
+  setLevel(levelName: LogLevelName): void {
+    this.level = LogLevel[levelName];
   }
 
   private log(level: LogLevel, message: string, ...args: any[]) {


### PR DESCRIPTION
## Summary
- Migrated server-side `console.*` calls to structured logger in `server/utils/config.ts` and `server/api/flags.get.ts`
- Documented logging conventions in CLAUDE.md (server vs client patterns)
- Removed stale comments from client components

## What's NOT included
**Web Analytics** is deferred - Cloudflare Web Analytics requires either:
- A custom domain (not `*.workers.dev`)
- Dashboard configuration that's outside code scope

The existing Workers Logs (via `observability` in wrangler.jsonc) provide server-side metrics.

## Test plan
- [x] All 102 unit tests pass
- [x] ESLint passes (warnings only, no errors)
- [x] Build succeeds

Closes #54 (duplicate of #23)
Partially addresses #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)