### PR TITLE
Phase 7: Timer & Round Management

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -30,7 +30,9 @@ Master kill switch (`APP_ENABLED` flag) returns maintenance page (503) when disa
   votesRevealed: boolean,
   storyTitle: string,
   votingScale?: string,      // fibonacci, modified-fibonacci, t-shirt, etc.
-  autoReveal?: boolean       // auto-reveal votes when everyone has voted
+  autoReveal?: boolean,      // auto-reveal votes when everyone has voted
+  timerEndTime?: number | null,  // Unix timestamp when timer expires
+  timerAutoReveal?: boolean      // auto-reveal when timer expires
 }
 ```
 
@@ -38,7 +40,7 @@ Master kill switch (`APP_ENABLED` flag) returns maintenance page (503) when disa
 All WebSocket messages follow:
 ```typescript
 {
-  type: 'auth' | 'join' | 'vote' | 'reveal' | 'reset' | 'ping' | 'pong' | 'setStory' | 'setScale' | 'setAutoReveal' | 'update' | 'error',
+  type: 'auth' | 'join' | 'vote' | 'reveal' | 'reset' | 'ping' | 'pong' | 'setStory' | 'setScale' | 'setAutoReveal' | 'startTimer' | 'cancelTimer' | 'setTimerAutoReveal' | 'update' | 'error',
   payload?: any
 }
 ```
@@ -46,6 +48,7 @@ All WebSocket messages follow:
 ### Key Features
 - **Multiple voting scales**: Fibonacci, Modified Fibonacci, T-Shirt sizes, Powers of 2
 - **Auto-reveal**: Automatically reveal votes when all participants have voted
+- **Timer**: Optional countdown timer (30s, 1m, 2m, 5m) with configurable auto-reveal on expiration
 - **Story titles**: Set context for each voting round
 - **Dark/light mode**: Theme support with system preference detection
 - **Session persistence**: Maintains user state across page refreshes and hibernation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,7 +307,7 @@ The client attempts reconnection with exponential backoff (max 10 attempts). Aft
 All WebSocket messages follow this structure:
 ```typescript
 {
-  type: 'join' | 'vote' | 'reveal' | 'reset' | 'setStory' | 'setScale' | 'setAutoReveal' | 'update' | 'error' | 'ping' | 'pong',
+  type: 'join' | 'vote' | 'reveal' | 'reset' | 'setStory' | 'setScale' | 'setAutoReveal' | 'startTimer' | 'cancelTimer' | 'setTimerAutoReveal' | 'update' | 'error' | 'ping' | 'pong',
   payload?: any
 }
 ```

--- a/components/ParticipantList.vue
+++ b/components/ParticipantList.vue
@@ -184,6 +184,9 @@ function getParticipantColor(userId: string): string {
       </p>
     </div>
 
+    <!-- Timer Controls -->
+    <TimerControls />
+
     <!-- Voting Progress -->
     <div
       v-if="roomState.participants.length > 0"

--- a/components/TimerControls.vue
+++ b/components/TimerControls.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { PokerRoomKey } from '~/composables/usePokerRoom';
+
+// Inject the poker room state and actions with type safety
+const pokerRoom = inject(PokerRoomKey);
+if (!pokerRoom) throw new Error('PokerRoom not provided');
+
+const {
+  roomState,
+  isJoined,
+  status,
+  timerRemaining,
+  timerExpired,
+  startTimer,
+  cancelTimer,
+  setTimerAutoReveal,
+} = pokerRoom;
+
+// Timer durations in seconds (must match server-side VALID_TIMER_DURATIONS)
+const TIMER_PRESETS = [
+  { label: '30s', value: 30 },
+  { label: '1m', value: 60 },
+  { label: '2m', value: 120 },
+  { label: '5m', value: 300 },
+] as const;
+
+// Format remaining time as M:SS
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+// Computed: is timer active?
+const isTimerActive = computed(() => timerRemaining.value !== null && timerRemaining.value > 0);
+
+// Computed: should show warning state (<=10 seconds)
+const isWarning = computed(() => timerRemaining.value !== null && timerRemaining.value <= 10 && timerRemaining.value > 0);
+
+// Handle timer auto-reveal toggle
+function handleTimerAutoRevealChange(event: Event) {
+  const target = event.target as HTMLInputElement;
+  setTimerAutoReveal(target.checked);
+}
+</script>
+
+<template>
+  <div
+    v-if="isJoined && !roomState.votesRevealed"
+    class="mt-4 border-t border-gray-200 dark:border-gray-600 pt-4"
+  >
+    <!-- Timer Expired Alert -->
+    <Transition
+      enter-active-class="transition ease-out duration-200"
+      enter-from-class="opacity-0 scale-95"
+      enter-to-class="opacity-100 scale-100"
+      leave-active-class="transition ease-in duration-150"
+      leave-from-class="opacity-100 scale-100"
+      leave-to-class="opacity-0 scale-95"
+    >
+      <div
+        v-if="timerExpired"
+        class="mb-3 rounded-md bg-red-100 dark:bg-red-900/30 px-3 py-2 text-center animate-pulse"
+      >
+        <span class="text-sm font-semibold text-red-700 dark:text-red-300">
+          Time's up!
+        </span>
+      </div>
+    </Transition>
+
+    <!-- Timer Display (when active) -->
+    <div
+      v-if="isTimerActive"
+      class="flex items-center justify-between mb-3"
+    >
+      <div
+        class="text-2xl font-mono font-bold transition-colors duration-200"
+        :class="{
+          'text-gray-900 dark:text-white': !isWarning,
+          'text-orange-600 dark:text-orange-400': isWarning,
+        }"
+      >
+        {{ formatTime(timerRemaining!) }}
+      </div>
+      <button
+        :disabled="status !== 'OPEN'"
+        class="rounded-md px-3 py-1.5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50 bg-gray-500 dark:bg-gray-600 hover:bg-gray-600 dark:hover:bg-gray-700"
+        @click="cancelTimer"
+      >
+        Cancel
+      </button>
+    </div>
+
+    <!-- Timer Preset Buttons (when not active) -->
+    <div
+      v-else
+      class="space-y-3"
+    >
+      <div class="flex items-center justify-between">
+        <span class="text-xs text-gray-500 dark:text-gray-400 transition-colors duration-200">
+          Timer
+        </span>
+      </div>
+      <div class="flex gap-2">
+        <button
+          v-for="preset in TIMER_PRESETS"
+          :key="preset.value"
+          :disabled="status !== 'OPEN'"
+          class="flex-1 rounded-md px-2 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 transition-colors disabled:cursor-not-allowed disabled:opacity-50 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+          @click="startTimer(preset.value)"
+        >
+          {{ preset.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Timer Auto-Reveal Toggle -->
+    <div class="mt-3 flex items-center gap-2">
+      <input
+        id="timer-auto-reveal"
+        type="checkbox"
+        :checked="roomState.timerAutoReveal"
+        :disabled="status !== 'OPEN'"
+        class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 dark:focus:ring-blue-400 disabled:cursor-not-allowed disabled:opacity-50"
+        @change="handleTimerAutoRevealChange"
+      />
+      <label
+        for="timer-auto-reveal"
+        class="text-xs text-gray-500 dark:text-gray-400 transition-colors duration-200"
+      >
+        Auto-reveal on timer
+      </label>
+    </div>
+  </div>
+</template>

--- a/composables/usePokerRoom.ts
+++ b/composables/usePokerRoom.ts
@@ -591,6 +591,7 @@ export function usePokerRoom(roomId: string) {
       reconnectTimeout = null;
     }
     stopHeartbeat();
+    stopTimerInterval();
 
     // Clear connection monitoring state to prevent memory leaks
     pingTimestamps.clear();

--- a/docs/plans/2025-11-29-timer-round-management-design.md
+++ b/docs/plans/2025-11-29-timer-round-management-design.md
@@ -1,0 +1,182 @@
+# Phase 7: Timer & Round Management Design
+
+## Overview
+
+Add optional timer for voting rounds with synchronization across participants. Timers help teams maintain focus and keep estimation sessions moving.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Who can control timer | Any participant | No roles exist yet; designed for easy role-gating later |
+| Synchronization model | Server-authoritative timestamp | Minimal network traffic; clients compute locally |
+| Timer expiration behavior | Configurable per-room | Reuses auto-reveal concept; flexibility for teams |
+| Duration options | Preset buttons only (30s, 1m, 2m, 5m) | Covers 95% of use cases; simpler UI |
+| Audio alerts | None (visual only) | Avoids autoplay complexity; can add later |
+| Timer on reset | Cancels automatically | Clean slate mental model |
+| UI placement | Between New Round button and voting progress | In the action area where most relevant |
+
+## Data Model
+
+### Server-side (PokerRoom Durable Object)
+
+Add to room state:
+
+```typescript
+timerEndTime: number | null    // Unix timestamp (ms) when timer expires
+timerAutoReveal: boolean       // Auto-reveal votes when timer expires (default: false)
+```
+
+### Client-side (RoomState interface)
+
+```typescript
+timerEndTime?: number | null
+timerAutoReveal?: boolean
+```
+
+### New Message Types
+
+| Type | Payload | Description |
+|------|---------|-------------|
+| `startTimer` | `{ duration: number }` | Start timer (duration in seconds: 30, 60, 120, 300) |
+| `cancelTimer` | none | Cancel running timer |
+| `setTimerAutoReveal` | `{ enabled: boolean }` | Toggle auto-reveal on timer expiration |
+
+## Server Logic (PokerRoom)
+
+### Starting a Timer
+
+1. Validate duration is one of: 30, 60, 120, 300 seconds
+2. Set `timerEndTime = Date.now() + (duration * 1000)`
+3. Broadcast room state update to all clients
+
+### Timer Expiration Handling
+
+The server does NOT run an interval. Instead, on any incoming message:
+
+1. Check if `timerEndTime !== null && Date.now() >= timerEndTime`
+2. If expired AND `timerAutoReveal === true` AND `votesRevealed === false`:
+   - Set `votesRevealed = true`
+3. Set `timerEndTime = null`
+4. Broadcast update
+
+Clients handle visual expiration independently since they know the end time.
+
+### Canceling a Timer
+
+1. Set `timerEndTime = null`
+2. Broadcast update
+
+### On Reset (New Round)
+
+Existing reset logic plus:
+- Set `timerEndTime = null` (cancel any running timer)
+- `timerAutoReveal` persists (room preference)
+
+### Future Role-Gating
+
+Timer actions route through a helper for easy role checks later:
+
+```typescript
+function canControlTimer(userId: string): boolean {
+  // Currently: anyone can control
+  // Future: check if user has facilitator role
+  return true;
+}
+```
+
+## Client Logic (usePokerRoom composable)
+
+### New Methods
+
+```typescript
+startTimer(duration: number): void    // Send startTimer message
+cancelTimer(): void                   // Send cancelTimer message
+setTimerAutoReveal(enabled: boolean): void
+```
+
+### New Computed State
+
+```typescript
+timerRemaining: ComputedRef<number | null>  // Seconds remaining, null if no timer
+timerExpired: ComputedRef<boolean>          // True when timer just reached zero
+```
+
+### Timer Countdown Logic
+
+1. When `timerEndTime` is set, start local `setInterval` (1 second)
+2. Calculate: `Math.max(0, Math.ceil((timerEndTime - Date.now()) / 1000))`
+3. When remaining hits 0, set `timerExpired = true` (triggers visual alert)
+4. Clear interval when timer cancelled or component unmounts
+5. On reconnection, `timerEndTime` comes in room state update automatically
+
+## UI Design
+
+### Timer Controls
+
+Located between New Round button and voting progress indicator.
+
+**When no timer running:**
+```
+[30s] [1m] [2m] [5m]
+```
+
+**When timer running:**
+```
+  2:00  [Cancel]
+```
+
+### Countdown Display
+
+| State | Appearance |
+|-------|------------|
+| Normal (>10s) | Neutral color, `M:SS` format |
+| Warning (≤10s) | Yellow/orange highlight |
+| Expired | Red background, "Time's up!" text |
+
+Format examples: "2:00", "0:30", "0:05"
+
+### Timer Auto-Reveal Toggle
+
+Checkbox near timer controls: "Auto-reveal on timer"
+- Follows same pattern as existing auto-reveal toggle
+- Persists as room setting
+
+### Visual Expiration Alert
+
+- Countdown area pulses briefly when hitting zero
+- "Time's up!" replaces countdown for ~3 seconds, then clears
+- No modal or blocking UI
+
+## Testing Strategy
+
+### Unit Tests (poker-room.test.ts)
+
+- `startTimer` sets correct `timerEndTime`
+- `startTimer` rejects invalid durations
+- `cancelTimer` clears `timerEndTime`
+- Reset clears `timerEndTime`
+- Timer expiration + `timerAutoReveal` triggers reveal
+- Timer expiration without `timerAutoReveal` doesn't reveal
+- `setTimerAutoReveal` updates setting
+
+### Component Tests
+
+- Timer buttons appear when no timer running
+- Countdown + cancel button appear when timer running
+- Countdown updates every second
+- Warning state at ≤10 seconds
+- Expired state shows "Time's up!"
+
+### E2E Tests
+
+- Start timer, verify synced across multiple clients
+- Cancel timer, verify cleared for all clients
+- Timer expiration with auto-reveal enabled
+- Reset during active timer cancels it
+
+## Implementation Notes
+
+- Timer precision of 1-2 seconds is acceptable
+- No audio alerts in initial implementation
+- Designed for future role-gating without breaking changes

--- a/server/poker-room.ts
+++ b/server/poker-room.ts
@@ -459,6 +459,10 @@ export class PokerRoom extends DurableObject {
           this.autoRevealTimeout = undefined;
         }
 
+        // Cancel active timer since votes are now revealed
+        // Timer's purpose was to reveal votes, which is now done
+        roomState.timerEndTime = null;
+
         roomState.votesRevealed = true;
         break;
       }
@@ -529,6 +533,10 @@ export class PokerRoom extends DurableObject {
           this.autoRevealTimeout = undefined;
         }
 
+        // Cancel active timer since votes are being cleared
+        // Timer would be meaningless with no votes to reveal
+        roomState.timerEndTime = null;
+
         // Update voting scale and clear all votes
         // Existing votes may be invalid on the new scale (e.g., "21" on Fibonacci → T-shirt sizes)
         roomState.votingScale = message.scale;
@@ -577,8 +585,8 @@ export class PokerRoom extends DurableObject {
           return;
         }
 
-        // Validate duration is one of the allowed presets
-        if (!VALID_TIMER_DURATIONS.includes(message.duration as typeof VALID_TIMER_DURATIONS[number])) {
+        // Validate duration is a number and one of the allowed presets
+        if (typeof message.duration !== 'number' || !VALID_TIMER_DURATIONS.includes(message.duration as typeof VALID_TIMER_DURATIONS[number])) {
           ws.send(JSON.stringify({
             type: 'error',
             payload: { message: 'Invalid timer duration. Use 30, 60, 120, or 300 seconds.' },


### PR DESCRIPTION
## Summary
- Add optional timer for voting rounds with server-authoritative timestamp sync
- Preset durations: 30s, 1m, 2m, 5m
- Configurable auto-reveal when timer expires (`timerAutoReveal` room setting)
- Timer clears automatically on round reset
- TimerControls component with visual warning states (≤10s warning, expired state)

## Implementation Details
- Server broadcasts absolute `timerEndTime` timestamp; clients compute countdown locally
- Timer expiration checked on every server message (no server-side interval needed)
- Designed for future role-gating (Issue #31) without breaking changes

## Test plan
- [x] All 112 unit tests pass
- [ ] Manual test: Start timer, verify countdown syncs across participants
- [ ] Manual test: Timer expiration with auto-reveal enabled
- [ ] Manual test: Timer expiration with auto-reveal disabled
- [ ] Manual test: Cancel timer mid-countdown
- [ ] Manual test: Reset round clears active timer

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)